### PR TITLE
Replace per-class toMessage() overrides with a single spread in GenericEvent

### DIFF
--- a/src/scene/events/setSceneEvent.ts
+++ b/src/scene/events/setSceneEvent.ts
@@ -10,13 +10,4 @@ export class SetSceneEvent extends GenericEvent {
         this.sceneName = sceneName;
         this.sceneSettings = sceneSettings;
     }
-
-    override toMessage() {
-        return {
-            target: this.target,
-            action: this.action,
-            sceneName: this.sceneName,
-            sceneSettings: this.sceneSettings,
-        };
-    }
 }

--- a/src/scene/events/setSceneSettingsEvent.ts
+++ b/src/scene/events/setSceneSettingsEvent.ts
@@ -8,12 +8,4 @@ export class SetSceneSettingsEvent extends GenericEvent {
         super(target, action);
         this.sceneSettings = sceneSettings;
     }
-
-    override toMessage() {
-        return {
-            target: this.target,
-            action: this.action,
-            sceneSettings: this.sceneSettings,
-        };
-    }
 }

--- a/src/userInterface/settings/events/SettingsWindowEvent.ts
+++ b/src/userInterface/settings/events/SettingsWindowEvent.ts
@@ -7,19 +7,4 @@ export class SettingsWindowEvent extends GenericEvent {
         super(target, action);
         this.source = source;
     }
-
-    override toMessage() {
-        const message: {
-            target: messageTarget;
-            action: messageAction;
-            source?: captureSource;
-        } = {
-            target: this.target,
-            action: this.action,
-        };
-        if (this.source !== undefined) {
-            message.source = this.source;
-        }
-        return message;
-    }
 }

--- a/src/utils/eventMessage.ts
+++ b/src/utils/eventMessage.ts
@@ -72,11 +72,10 @@ export class GenericEvent {
         this.action = action;
     }
 
+    // Spread copies all own enumerable fields, so subclasses inherit this as-is.
+    // (Methods live on the prototype and are not copied.)
     toMessage() {
-        return {
-            target: this.target,
-            action: this.action,
-        };
+        return { ...this };
     }
 }
 export class AudioDataEvent extends GenericEvent {
@@ -85,14 +84,6 @@ export class AudioDataEvent extends GenericEvent {
     constructor(target: messageTarget, action: messageAction, audioData: IAudioDataDto) {
         super(target, action);
         this.audioData = audioData;
-    }
-
-    override toMessage() {
-        return {
-            target: this.target,
-            action: this.action,
-            audioData: this.audioData,
-        };
     }
 }
 export class InitiateStreamEvent extends GenericEvent {
@@ -104,23 +95,6 @@ export class InitiateStreamEvent extends GenericEvent {
         this.streamId = streamId;
         this.source = source;
     }
-
-    override toMessage() {
-        const message: {
-            target: messageTarget;
-            action: messageAction;
-            streamId: string;
-            source?: captureSource;
-        } = {
-            target: this.target,
-            action: this.action,
-            streamId: this.streamId,
-        };
-        if (this.source !== undefined) {
-            message.source = this.source;
-        }
-        return message;
-    }
 }
 export class StartStreamEvent extends GenericEvent {
     streamType: streamType;
@@ -129,13 +103,6 @@ export class StartStreamEvent extends GenericEvent {
         super(target, action);
         this.streamType = streamType;
     }
-    override toMessage() {
-        return {
-            target: this.target,
-            action: this.action,
-            streamType: this.streamType,
-        };
-    }
 }
 export class SetFpsEvent extends GenericEvent {
     fps: number;
@@ -143,14 +110,6 @@ export class SetFpsEvent extends GenericEvent {
     constructor(target: messageTarget, action: messageAction, fps: number) {
         super(target, action);
         this.fps = fps;
-    }
-
-    override toMessage() {
-        return {
-            target: this.target,
-            action: this.action,
-            fps: this.fps,
-        };
     }
 }
 export class UpdateSettingsCacheEvent extends GenericEvent {
@@ -162,15 +121,6 @@ export class UpdateSettingsCacheEvent extends GenericEvent {
         this.key = key;
         this.value = value;
     }
-
-    override toMessage() {
-        return {
-            target: this.target,
-            action: this.action,
-            key: this.key,
-            value: this.value,
-        };
-    }
 }
 export class ShowFpsOverlayEvent extends GenericEvent {
     value: boolean;
@@ -178,14 +128,6 @@ export class ShowFpsOverlayEvent extends GenericEvent {
     constructor(target: messageTarget, value: boolean) {
         super(target, messageAction.showFpsOverlay);
         this.value = value;
-    }
-
-    override toMessage() {
-        return {
-            target: this.target,
-            action: this.action,
-            value: this.value,
-        };
     }
 }
 export class RestartCaptureEvent extends GenericEvent {
@@ -196,15 +138,6 @@ export class RestartCaptureEvent extends GenericEvent {
         super(messageTarget.background, messageAction.restartCapture);
         this.nonce = nonce;
         this.source = source;
-    }
-
-    override toMessage() {
-        return {
-            target: this.target,
-            action: this.action,
-            nonce: this.nonce,
-            source: this.source,
-        };
     }
 }
 export class RestartCaptureAckEvent extends GenericEvent {
@@ -218,16 +151,6 @@ export class RestartCaptureAckEvent extends GenericEvent {
         this.success = success;
         this.activeSource = activeSource;
     }
-
-    override toMessage() {
-        return {
-            target: this.target,
-            action: this.action,
-            nonce: this.nonce,
-            success: this.success,
-            activeSource: this.activeSource,
-        };
-    }
 }
 export class AnimationReadyEvent extends GenericEvent {
     storedSettings?: Record<string, string>;
@@ -235,13 +158,5 @@ export class AnimationReadyEvent extends GenericEvent {
     constructor(storedSettings?: Record<string, string>) {
         super(messageTarget.animation, messageAction.animationReady);
         this.storedSettings = storedSettings;
-    }
-
-    override toMessage() {
-        return {
-            target: this.target,
-            action: this.action,
-            storedSettings: this.storedSettings,
-        };
     }
 }


### PR DESCRIPTION
## What

Removes ~120 lines of hand-written serialization boilerplate from the event/message classes. Every subclass of `GenericEvent` overrode `toMessage()` just to re-list its own fields; the base class now does it once with an object spread:

```ts
toMessage() {
    return { ...this };
}
```

All 12 subclass overrides are deleted (`eventMessage.ts`, `SetSceneEvent`, `SetSceneSettingsEvent`, `SettingsWindowEvent`). Adding a field to an event class no longer requires remembering to also add it to `toMessage()`.

## Why this is behavior-preserving

- All event fields are enumerable own properties, so `{ ...this }` produces the same message object; methods live on the prototype and are not copied.
- `InitiateStreamEvent` and `SettingsWindowEvent` previously omitted an `undefined` `source` key; the spread keeps it as `source: undefined`. No receiver distinguishes the two — every reader uses `.source` with `??`/ternary fallbacks (`offscreenWindow/main.ts:128`, `background.ts:140`, `sandbox/main.ts:113`), and `chrome.runtime.sendMessage` drops `undefined` values during JSON serialization anyway.

## Verification

- `pnpm run compile` (tsc) and `pnpm run lint` (biome) pass.
- Playwright e2e suite: **29/30 passed**. The single failure ("FPS emission requires a valid message source") also fails on the unmodified base branch in the same environment (which additionally flaked on one capture-source test, 28/30) — pre-existing flakiness, unrelated to this change.

No overlap with `drop-sandbox-iframe-butterchurn3` — that branch doesn't touch these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152TXW9J4VcAkvuNYn6hYBh

---
_Generated by [Claude Code](https://claude.ai/code/session_0152TXW9J4VcAkvuNYn6hYBh)_